### PR TITLE
style :root instead of #app

### DIFF
--- a/site/src/style.css
+++ b/site/src/style.css
@@ -7,7 +7,7 @@ body,
 	height: 100%;
 }
 
-#app {
+:root {
 	--bg-1: #0b0a0b;
 	--bg-2: #141214;
 	--bg-3: #211e21;


### PR DESCRIPTION
right now firefox's overscroll looks terrible
<img width="2944" height="1616" alt="image" src="https://github.com/user-attachments/assets/8e74e20e-b127-4667-8929-aac5d1370b3c" />
moving the styles to :root will fix this