### PR TITLE
Fix css ssr generation bug

### DIFF
--- a/src/core/jsx/index.ts
+++ b/src/core/jsx/index.ts
@@ -151,7 +151,9 @@ function _jsx(
 					throw new Error("Wrapper components cannot have CSS");
 			}
 
-			(el as ComponentInstance<any>).$ = cx;
+			if (!(el as ComponentInstance<any>).$ || cssInfo) {
+					(el as ComponentInstance<any>).$ = cx;
+			}
 
 			el.classList.add(CSS_COMPONENT);
 


### PR DESCRIPTION
This PR patches bugged behavior in situations like the following:

https://github.com/user-attachments/assets/e92bc964-7d81-4622-b456-d1a74b521755

```tsx
import { css, type FC, type ComponentChild  } from "dreamland/core";

export function PageTemplate(this: FC<{ children?: ComponentChild }, {}>) {
  return (
    <div>
      <div class="container">
        <div class="paragraph">
          <h1 class="title lato-black">Palatine Hill</h1>
          <div class="border" />
        </div>
        <h3 class="lato-bold paragraph">{this.children}</h3>
      </div>
    </div>
  );
}

PageTemplate.style = css`
  .title {
    width: 300px;
    margin-bottom: 0;
    font-size: xxx-large;
  }

  .container {
    margin-top: 40px;

    color: #5c4e43;
  }
  @media screen and (width >= 800px) {
    .container {
      margin-left: calc((100vw - 70vw) / 2);
      margin-right: calc((100vw - 70vw) / 2);
    }
  }

  @media screen and (width < 800px) {
    .paragraph {
      margin: 10px;
    }
  }
  .border {
    position: absolute;
    width: 260px;
    border: 2px solid #5c4e43;
    filter: url(#squiggle);
  }
`;

export function Page404(this: FC<{}, {}>) {
  return (
    <PageTemplate>
      404, Hill not found.
    </PageTemplate>
  );
}
```

With this PR the bug is patched.

As I understand it the issues was with the SSR vdom not properly including the css id for all components. This traces back to an issue in src/core/jsx/index.ts where the element $ was set multiple times and on occasion with undefined values.

No idea where these undefined values come from.

Full disclosure here's the LLM outputs that I used: https://claude.ai/share/72dd5ce3-fdab-43e0-adff-4c6102d17d1c
